### PR TITLE
Supermarket displays 'View Source' and 'View Issues' links

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,5 +5,7 @@ license          'Apache 2.0'
 description      'Custom resources useful for AIX systems'
 long_description 'Custom resources useful for AIX systems'
 version          '0.0.2'
+source_url       'https://github.com/opscode-cookbooks/aix'
+issues_url       'https://github.com/opscode-cookbooks/aix/issues'
 
 supports 'aix', '>= 6.1'


### PR DESCRIPTION
Adding the source_url and issues_url to the metadata.rb makes thes links visible when the cookbook is published to the supermarket.